### PR TITLE
BREAKING CHANGE: using Luxon instead of JS Date

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "luxon",
         "telebot"
     ]
 }

--- a/index.ts
+++ b/index.ts
@@ -5,17 +5,17 @@ import { config } from 'dotenv';
 config();
 
 import { Telegraf, Markup } from 'telegraf';
+import { DateTime } from 'luxon';
 import {
   getWeekNumber,
   parityOfWeek,
-  numberCouples,
   parityWeek,
   loadJSON,
   returnScheduleFromDayOfWeek,
   returnCouplesMessage,
   returnScheduleFromWeek,
 } from './src/utils.js';
-import { Couples, Parity, Schedule } from './src/types/index.types.js';
+import { Schedule } from './src/types/index.types.js';
 
 const bot = new Telegraf(process.env.BOT_TOKEN as string);
 
@@ -29,17 +29,13 @@ bot.start(async (ctx) => {
   );
 });
 
-const loadJsonAndReturnedAll = (newDate?: Date) => {
+const loadScheduleAndReturnAll = (newDate?: DateTime) => {
   const scheduleJson: Schedule[] = loadJSON('./schedule.json');
 
-  const currentDate = new Date();
-
-  if (newDate) {
-    currentDate.setTime(newDate.getTime());
-  }
+  const currentDate = newDate ? newDate : DateTime.now();
 
   const weekNumber = getWeekNumber(currentDate);
-  const dayOfWeek = currentDate.toLocaleString('ru-RU', { weekday: 'long' });
+  const dayOfWeek = currentDate.toLocaleString({ weekday: 'long' });
   const parity = parityOfWeek(currentDate);
 
   return {
@@ -52,7 +48,7 @@ const loadJsonAndReturnedAll = (newDate?: Date) => {
 };
 
 bot.hears('👁 Schedule', (ctx) => {
-  const { scheduleJson, weekNumber, dayOfWeek, parity } = loadJsonAndReturnedAll();
+  const { scheduleJson, weekNumber, dayOfWeek, parity } = loadScheduleAndReturnAll();
 
   const findedSchedule = returnScheduleFromDayOfWeek(scheduleJson, dayOfWeek, parity, weekNumber);
 
@@ -66,11 +62,9 @@ ${findedSchedule.map((value) => returnCouplesMessage(value)).join('\n\n')}
 });
 
 bot.hears('След.день', (ctx) => {
-  const nextDay = new Date();
-  nextDay.setDate(nextDay.getDate() + 1);
-  nextDay.setHours(nextDay.getHours() + 3);
+  const nextDay = DateTime.now().plus({ day: 1 });
 
-  const { scheduleJson, weekNumber, dayOfWeek, parity } = loadJsonAndReturnedAll(nextDay);
+  const { scheduleJson, weekNumber, dayOfWeek, parity } = loadScheduleAndReturnAll(nextDay);
 
   const findedSchedule = returnScheduleFromDayOfWeek(scheduleJson, dayOfWeek, parity, weekNumber);
 
@@ -84,11 +78,9 @@ ${findedSchedule.map((value) => returnCouplesMessage(value)).join('\n\n')}
 });
 
 bot.hears('След.неделя', (ctx) => {
-  const nextWeek = new Date();
-  nextWeek.setDate(nextWeek.getDate() + 7);
-  nextWeek.setHours(nextWeek.getHours() + 3);
+  const nextWeek = DateTime.now().plus({ week: 1 });
 
-  const { scheduleJson, weekNumber, parity } = loadJsonAndReturnedAll(nextWeek);
+  const { scheduleJson, weekNumber, parity } = loadScheduleAndReturnAll(nextWeek);
 
   const findedSchedule = returnScheduleFromWeek(scheduleJson, parity, weekNumber);
 
@@ -108,7 +100,7 @@ bot.hears('След.неделя', (ctx) => {
 });
 
 bot.hears('Вся неделя', (ctx) => {
-  const { scheduleJson, weekNumber, parity } = loadJsonAndReturnedAll();
+  const { scheduleJson, weekNumber, parity } = loadScheduleAndReturnAll();
 
   const findedSchedule = returnScheduleFromWeek(scheduleJson, parity, weekNumber);
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^16.3.1",
+    "luxon": "^3.4.3",
     "telegraf": "^4.13.1"
   },
   "devDependencies": {
+    "@types/luxon": "^3.3.2",
     "@types/node": "^20.5.9"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@telegraf/types/-/types-6.8.1.tgz#c9c567e8ba4fb3c656494f3901a7dfb22cb7d676"
   integrity sha512-JCRQuPPDCreYQaAeOwnqIlWrs8pJVvaNEUWBVNvdK3oJoTUKyBV+3TsPrIcnGqLeapptznuTk5s4udTlZPvGTA==
 
+"@types/luxon@^3.3.2":
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/@types/luxon/-/luxon-3.3.2.tgz#f6e3524c2486b949a4db445e85d93c8e9886dfe2"
+  integrity sha512-l5cpE57br4BIjK+9BSkFBOsWtwv6J9bJpC7gdXIzZyI0vuKvNTk0wZZrkQxMGsUAuGW9+WMNWF2IJMD7br2yeQ==
+
 "@types/node@^20.5.9":
   version "20.5.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.9.tgz#a70ec9d8fa0180a314c3ede0e20ea56ff71aed9a"
@@ -53,6 +58,11 @@ event-target-shim@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
   integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
+
+luxon@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.4.3.tgz#8ddf0358a9492267ffec6a13675fbaab5551315d"
+  integrity sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==
 
 mri@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Как я и говорил в #2 в данном обновлении управление временем было переписано с помощью пакета [luxon](https://www.npmjs.com/package/luxon)